### PR TITLE
chore: delegate_to_localhost

### DIFF
--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -28,7 +28,7 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-  connection: local
+  delegate_to: localhost
   with_items: "{{ config_files_local }}"
 
 - name: Read local config files into variables


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Chore

#### Changed behavior

Use `delegate_to: localhost` instead of `connection: local` due to `ansible` requirements.

